### PR TITLE
Add a huge redemption spec to check gas cost

### DIFF
--- a/contracts/PriorityRegistry.sol
+++ b/contracts/PriorityRegistry.sol
@@ -71,6 +71,7 @@ contract PriorityRegistry is IPriorityRegistry {
         onlyYamato
         returns (uint256 _newICRpercent)
     {
+        // uint256 gasStart = gasleft();
         require(
             !(_pledge.coll == 0 && _pledge.debt == 0 && _pledge.priority != 0),
             "Upsert Error: The logless zero pledge cannot be upserted. It should be removed."
@@ -138,6 +139,7 @@ contract PriorityRegistry is IPriorityRegistry {
         }
 
         if (_traverseStartICR > 0) _traverseToNextLICR(_traverseStartICR);
+        // console.log("gasUsed:upsert(): %s", gasStart - gasleft());
     }
 
     /*


### PR DESCRIPTION
# What I did
- Added a "huge redemption" spec to check gas cost
  - 20 accounts with 5ETH deposit
  - 100ETH-equiv redemption
  - It was `7015000 gas`. Seems good for cheap market-bought CJPY sellers