### PR TITLE
disabled Slither because it's buggy

### DIFF
--- a/.github/workflows/slither-analyze.yaml
+++ b/.github/workflows/slither-analyze.yaml
@@ -2,10 +2,10 @@ name: Slither Analyze
 on:
   push:
     branches:
-      - master
+      - turnOffUntilIssue76IsSolved
   pull_request:
     branches:
-      - master
+      - turnOffUntilIssue76IsSolved
 
 jobs:
   unit-tests:


### PR DESCRIPTION
# What I did
- Currently Slither was running for every each pull-request and it isn't blocking even if it failed
- But since after https://github.com/DeFiGeek-Community/yamato/pull/75, it blocks merging because of the issue https://github.com/DeFiGeek-Community/yamato/issues/76
- Hence the issue is not reported in the Slither-side (note: Slither is actively updated for now 2021/10), I temporally turn off Slither check.