### PR TITLE
Add a rough redeemable cap logic to ambiguously use it in testnet dem…

### DIFF
--- a/contracts/Dependencies/PledgeLib.sol
+++ b/contracts/Dependencies/PledgeLib.sol
@@ -142,8 +142,8 @@ library PledgeLib {
     function cappedRedemptionAmount(
         IYamato.Pledge memory pledge,
         uint256 mcr,
-        uint256 ethPriceInCurrency
-    ) public view returns (uint256 diff) {
+        address feed
+    ) public view returns (uint256) {
         /*
             collValuAfter/debtAfter = mcr/10000
             debtAfter = debtBefore - diff
@@ -151,9 +151,16 @@ library PledgeLib {
             10000 * (diff - collValuBefore) = mcr * (diff - debtBefore)
             (mcr - 10000) * diff = mcr * debtBefore - 10000 * collValuBefore
             diff = (mcr * debtBefore - 10000 * collValuBefore) / (mcr - 10000) 
+            diff =  (mcr - icrBefore) / (mcr - 10000) * debtBefore
+
+            [ Appendix. ]
+            Let k = (mcr - icrBefore) / (mcr - 10000)
+            diff = k * debtBefore
+
+            Given mcr = 13000, then
+            k = (13000 - icrBefore) / 3000
+              = -0.00033333333icrBefore + 4.33333333333 [10000<icrBefore<13000, 0<k<1]
         */
-        uint256 debtBefore = pledge.debt;
-        uint256 collValuBefore = (pledge.coll * ethPriceInCurrency) / 1e18;
-        diff = (mcr * debtBefore - 10000 * collValuBefore) / (mcr - 10000);
+        return (pledge.debt * (mcr - getICR(pledge, feed))) / (mcr - 10000);
     }
 }

--- a/contracts/YamatoRedeemerV3.sol
+++ b/contracts/YamatoRedeemerV3.sol
@@ -213,7 +213,7 @@ contract YamatoRedeemerV3 is IYamatoRedeemer, YamatoAction {
             // Note: Risky pledges. 10000<ICR<13000 redemption recovers ICR and calculations are tricky.
             uint256 cappedRedemptionAmount = sPledge.cappedRedemptionAmount(
                 mcr,
-                ethPriceInCurrency
+                feed()
             );
 
             if (cappedRedemptionAmount < currencyAmount) {

--- a/test/unit/PriorityRegistry.test.ts
+++ b/test/unit/PriorityRegistry.test.ts
@@ -757,9 +757,9 @@ describe("contract PriorityRegistry", function () {
   });
 
   describe("getRedeemablesCap()", function () {
-    it.skip(`should return some value`, async function () {
-      const _coll1 = BigNumber.from(1e18 + "");
-      const _debt1 = BigNumber.from(410000).mul(1e18 + "");
+    it(`should return some value with rank 101`, async function () {
+      const _coll1 = BigNumber.from(101).mul(1e16 + "");
+      const _debt1 = BigNumber.from(410000).mul(1e18 + ""); // PRICE=410000, ICR=100%
       const _prio1 = BigNumber.from(100 + "");
       for (var i = 0; i < 10; i++) {
         await (
@@ -790,7 +790,83 @@ describe("contract PriorityRegistry", function () {
 
       const cap = await priorityRegistry.getRedeemablesCap();
 
-      expect(cap).to.equal(PRICE.mul(_coll1.mul(10)).div(1e18 + ""));
+      expect(cap).to.equal("3566999999999999999999997");
+    });
+
+    it(`should return some value with rank 99`, async function () {
+      const _coll1 = BigNumber.from(99).mul(1e16 + "");
+      const _debt1 = BigNumber.from(410000).mul(1e18 + ""); // PRICE=410000, ICR=100%
+      const _prio1 = BigNumber.from(100 + "");
+      for (var i = 0; i < 10; i++) {
+        await (
+          await yamatoDummy.bypassUpsert(
+            toTyped([
+              _coll1,
+              _debt1,
+              true,
+              await accounts[i].getAddress(),
+              _prio1,
+            ])
+          )
+        ).wait();
+      }
+      for (var i = 10; i < 20; i++) {
+        await (
+          await yamatoDummy.bypassUpsert(
+            toTyped([
+              _coll1,
+              _debt1.div(2),
+              true,
+              await accounts[i].getAddress(),
+              _prio1,
+            ])
+          )
+        ).wait();
+      }
+
+      const cap = await priorityRegistry.getRedeemablesCap();
+
+      expect(cap).to.equal("3653100000000000000000000");
+    });
+
+    it(`should return some value with destroyed queue`, async function () {
+      const _coll1 = BigNumber.from(100).mul(1e16 + "");
+      const _debt1 = BigNumber.from(410000).mul(1e18 + ""); // PRICE=410000, ICR=100%
+      const _prio1 = BigNumber.from(100 + "");
+      for (var i = 0; i < 10; i++) {
+        await (
+          await yamatoDummy.bypassUpsert(
+            toTyped([
+              _coll1,
+              _debt1,
+              true,
+              await accounts[i].getAddress(),
+              _prio1,
+            ])
+          )
+        ).wait();
+      }
+      for (var i = 10; i < 20; i++) {
+        await (
+          await yamatoDummy.bypassUpsert(
+            toTyped([
+              _coll1,
+              _debt1.div(2),
+              true,
+              await accounts[i].getAddress(),
+              _prio1,
+            ])
+          )
+        ).wait();
+      }
+
+      await (
+        await yamatoDummy.bypassRankedQueueSearchAndDestroy(100, 5)
+      ).wait();
+
+      const cap = await priorityRegistry.getRedeemablesCap();
+
+      expect(cap).to.equal("3280000000000000000000000");
     });
   });
   describe("getSweepablesCap()", function () {


### PR DESCRIPTION
# What I did
- `getRedeemableCap()` had been broken since the `levelIndice` to `rankedQueue` data structure change
- For completing upgrade, `getRedeemableCap()` but must be fixed temporary.
- But it's not meant to be prod completed logic