### PR TITLE
Chore/upgrade priority registry v2 to v3 and sync

### DIFF
--- a/contracts/PriorityRegistryV3.sol
+++ b/contracts/PriorityRegistryV3.sol
@@ -444,27 +444,12 @@ contract PriorityRegistryV3 is IPriorityRegistryV3, YamatoStore {
                     if (_nextout < rankedQueueTotalLen(_rank)) {
                         // icr check and cap addition
                         if (_icr >= 10000) {
-                            console.log(
-                                "[above] _icr:%s, _nextout:%s, add:%s",
-                                _icr,
-                                _nextout,
-                                _pledge.cappedRedemptionAmount(
-                                    mcrPercent * 100,
-                                    feed()
-                                )
-                            );
                             // icr=130%-based value
                             _cap += _pledge.cappedRedemptionAmount(
                                 mcrPercent * 100,
                                 feed()
                             );
                         } else {
-                            console.log(
-                                "[below] _icr:%s, _nextout:%s, add:%s",
-                                _icr,
-                                _nextout,
-                                (_pledge.coll * ethPriceInCurrency) / 1e18
-                            );
                             // coll-based value
                             _cap += (_pledge.coll * ethPriceInCurrency) / 1e18;
                         }
@@ -498,16 +483,17 @@ contract PriorityRegistryV3 is IPriorityRegistryV3, YamatoStore {
         return _ICRpertenk / 100;
     }
 
-
-
     /*
         ====================
             Upgrade Helpers
         ====================
         - syncRankedQueue
     */
-    function syncRankedQueue(IYamato.Pledge[] calldata pledges) public onlyGovernance {
-        for(uint i = 0; i < pledges.length; i++) {
+    function syncRankedQueue(IYamato.Pledge[] calldata pledges)
+        public
+        onlyGovernance
+    {
+        for (uint256 i = 0; i < pledges.length; i++) {
             this.upsert(pledges[i]);
         }
     }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "upgrade:currencyOS": "hardhat run upgrade/004_upgrade_CurrencyOS.ts --network rinkeby",
     "upgrade:pool": "hardhat run upgrade/006_upgrade_Pool.ts --network rinkeby",
     "upgrade:priorityRegistry": "hardhat run upgrade/005_upgrade_PriorityRegistry.ts --network rinkeby",
-    "upgradeSync:priorityRegistry": "ts-node upgrade/007_sync_PriorityRegistry.ts --rinkeby",
     "upgrade:redeemer": "hardhat run upgrade/002_upgrade_YamatoRedeemer.ts --network rinkeby",
     "upgrade:repayer": "hardhat run upgrade/001_upgrade_YamatoRepayer.ts --network rinkeby",
     "upgrade:withdrawer": "hardhat run upgrade/003_upgrade_YamatoWithdrawer.ts --network rinkeby",
+    "upgradeSync:priorityRegistry": "ts-node upgrade/007_sync_PriorityRegistry.ts --rinkeby",
     "verify:rinkeby": "hardhat verify --network rinkeby",
     "verify:rinkeby:all": "hardhat run src/verifyRinkebyContracts.ts",
     "verify:rinkeby:showURL": "ts-node src/showRinkebyProxyVerificationURLs.ts"

--- a/src/testUtil.ts
+++ b/src/testUtil.ts
@@ -29,7 +29,11 @@ export async function getFakeProxy<T extends BaseContract>(
 export async function getProxy<
   T extends BaseContract,
   S extends ContractFactory
->(contractName: string, args: any, versionSpecification?: number|undefined): Promise<T> {
+>(
+  contractName: string,
+  args: any,
+  versionSpecification?: number | undefined
+): Promise<T> {
   let contractFactory: S = <S>await ethers.getContractFactory(contractName);
   const defaultInst: T = <T>(
     await upgrades.deployProxy(contractFactory, args, { kind: "uups" })
@@ -37,7 +41,7 @@ export async function getProxy<
 
   // TODO: V2 Flag
   let implName;
-  if(versionSpecification) {
+  if (versionSpecification) {
     implName = `${contractName}V${versionSpecification}`;
   } else {
     implName = getLatestContractName(contractName);
@@ -56,7 +60,12 @@ export async function getProxy<
 export async function getLinkedProxy<
   T extends BaseContract,
   S extends ContractFactory
->(contractName: string, args: Array<any>, libralies: string[], versionSpecification?: number|undefined): Promise<T> {
+>(
+  contractName: string,
+  args: Array<any>,
+  libralies: string[],
+  versionSpecification?: number | undefined
+): Promise<T> {
   console.log(`getLinkedProxy: deploying libs...`);
   let Libraries = {};
   for (var i = 0; i < libralies.length; i++) {
@@ -73,7 +82,7 @@ export async function getLinkedProxy<
   });
 
   let implName;
-  if(versionSpecification) {
+  if (versionSpecification) {
     implName = `${contractName}V${versionSpecification}`;
   } else {
     implName = getLatestContractName(contractName);

--- a/src/upgradeUtil.ts
+++ b/src/upgradeUtil.ts
@@ -114,13 +114,21 @@ export function getLatestContractName(implNameBase) {
   }
 }
 
-export async function upgradePriorityRegistryV2ToV3AndSync(PriorityRegistry:PriorityRegistry, pledges:{
-  coll: BigNumberish;
-  debt: BigNumberish;
-  isCreated: boolean;
-  owner: string;
-  priority: BigNumberish;
-}[]){
-  const inst:PriorityRegistryV3 = <PriorityRegistryV3>await upgradeProxy(PriorityRegistry.address, "PriorityRegistryV3");
+export async function upgradePriorityRegistryV2ToV3AndSync(
+  PriorityRegistry: PriorityRegistry,
+  pledges: {
+    coll: BigNumberish;
+    debt: BigNumberish;
+    isCreated: boolean;
+    owner: string;
+    priority: BigNumberish;
+  }[]
+): Promise<PriorityRegistryV3> {
+  const inst: PriorityRegistryV3 = <PriorityRegistryV3>(
+    await upgradeLinkedProxy(PriorityRegistry.address, "PriorityRegistryV3", [
+      "PledgeLib",
+    ])
+  );
   await inst.syncRankedQueue(pledges);
+  return inst;
 }

--- a/upgrade/007_sync_PriorityRegistry.ts
+++ b/upgrade/007_sync_PriorityRegistry.ts
@@ -17,7 +17,7 @@ let PriorityRegistryERC1967Proxy = readFileSync(
 ).toString();
 
 async function main() {
-    await setProvider();
+  await setProvider();
   let Yamato = new ethers.Contract(
     YamatoERC1967Proxy,
     genABI(NAME1),
@@ -29,19 +29,17 @@ async function main() {
     getFoundation()
   );
 
-//   await (await Yamato.pause()).wait();
-
-  let filter = Yamato.filters.Deposited(null, null)
+  let filter = Yamato.filters.Deposited(null, null);
   let logs = await Yamato.queryFilter(filter);
 
-  let pledges = await Promise.all(logs.map(async (log) => {
-    return await Yamato.getPledge(log.args.sender);
-  }))
-  console.log(pledges);
+  let pledgeOwners = logs
+    .map((log) => log.args.sender)
+    .filter((value, index, self) => self.indexOf(value) === index);
+  let pledges = await Promise.all(
+    pledgeOwners.map(async (owner) => await Yamato.getPledge(owner))
+  );
 
-//   await PriorityRegistry.syncRankedQueue(pledges);
-
-//   await (await Yamato.unpause()).wait();
+  await PriorityRegistry.syncRankedQueue(pledges);
 }
 
 main().catch((e) => console.log(e));


### PR DESCRIPTION
# What I did
- Copy the "price change" specs (= real scenario redemption and sweeping specs) and modify it as "Prepare data as V2 but run it as V3"
- This would be a local emulation of the stateful real world Yamato
- And that specs didn't show any errors. Upgrade may not have degressions.