### PR TITLE
Changed type for constants from int to uint. Modified test names

### DIFF
--- a/contracts/curveFork/VotingEscrow.sol
+++ b/contracts/curveFork/VotingEscrow.sol
@@ -40,10 +40,10 @@ contract VotingEscrow is ReentrancyGuard {
         uint256 end;
     }
 
-    int128 constant DEPOSIT_FOR_TYPE = 0;
-    int128 constant CREATE_LOCK_TYPE = 1;
-    int128 constant INCREASE_LOCK_AMOUNT = 2;
-    int128 constant INCREASE_UNLOCK_TIME = 3;
+    uint128 private constant DEPOSIT_FOR_TYPE = 0;
+    uint128 private constant CREATE_LOCK_TYPE = 1;
+    uint128 private constant INCREASE_LOCK_AMOUNT = 2;
+    uint128 private constant INCREASE_UNLOCK_TIME = 3;
 
     event CommitOwnership(address admin);
     event ApplyOwnership(address admin);
@@ -51,7 +51,7 @@ contract VotingEscrow is ReentrancyGuard {
         address indexed provider,
         uint256 value,
         uint256 indexed locktime,
-        int128 _type,
+        uint128 _type,
         uint256 ts
     );
     event Withdraw(address indexed provider, uint256 value, uint256 ts);
@@ -232,7 +232,7 @@ contract VotingEscrow is ReentrancyGuard {
                 }
                 _uOld.bias =
                     _uOld.slope *
-                    int128(uint128(oldLocked_.end) - uint128(block.timestamp));
+                    int128(uint128(oldLocked_.end - block.timestamp));
             }
 
             if (newLocked_.end > block.timestamp && newLocked_.amount > 0) {
@@ -243,7 +243,7 @@ contract VotingEscrow is ReentrancyGuard {
                 }
                 _uNew.bias =
                     _uNew.slope *
-                    int128(uint128(newLocked_.end) - uint128(block.timestamp));
+                    int128(uint128(newLocked_.end - block.timestamp));
             }
 
             // Read values of scheduled changes in the slope
@@ -415,7 +415,7 @@ contract VotingEscrow is ReentrancyGuard {
         uint256 value_,
         uint256 unlockTime_,
         LockedBalance memory lockedBalance_,
-        int128 type_
+        uint128 type_
     ) internal {
         LockedBalance memory _locked = LockedBalance(
             lockedBalance_.amount,

--- a/test/fork/integration/Minter/components.test.ts
+++ b/test/fork/integration/Minter/components.test.ts
@@ -14,7 +14,7 @@ const SCALE = BigNumber.from((1e20).toString());
 const WEEK = 86400 * 7;
 const MONTH = 86400 * 30;
 
-describe("Liquidity Gauge Tests", function () {
+describe("Minter components", function () {
   let accounts: SignerWithAddress[];
   let gaugeController: Contract;
   let liquidityGauge: Contract;

--- a/test/fork/integration/Minter/minterIntegration.test.ts
+++ b/test/fork/integration/Minter/minterIntegration.test.ts
@@ -13,7 +13,7 @@ const WEEK = 86400 * 7;
 const MONTH = 86400 * 30;
 const W = BigNumber.from(10).pow(18);
 
-describe("Liquidity Gauge Tests", function () {
+describe("Minter integration", function () {
   let admin, bob, charlie, dan: SignerWithAddress;
   let gaugeController: Contract;
   let threeGauges: Contract[3] = [];


### PR DESCRIPTION
## What I did
1. 定数の型をint128からuint128へ変更

#### gasの変化（ `integration/VotingEscrow/votingEscrow.test.ts` で検証）

Deployment: 2695455 -> 2695047 
createLock: 335341 -> 335303
withdraw: 211295 -> 211295

2. Minterのテスト名変更